### PR TITLE
Handle old film review titles

### DIFF
--- a/films/src/main/scala/com/gu/film_review_parser/parsers/FilmReviewParser.scala
+++ b/films/src/main/scala/com/gu/film_review_parser/parsers/FilmReviewParser.scala
@@ -31,10 +31,12 @@ object FilmReviewParser {
     parsed
   }
 
-  val titlePattern = """^(.*) review ?(–|-|:).*""".r
+  val newerTitlePattern = """^(.*) review ?(–|-|:).*""".r   //since Feb 2014
+  val olderTitlePattern = """^(.*) (–|-|:) review.*""".r
   private def getTitle(text: String): Option[String] = {
     text match {
-      case titlePattern(title,_) => Some(title.trim)
+      case newerTitlePattern(title,_) => Some(title.trim)
+      case olderTitlePattern(title,_) => Some(title.trim)
       case _ => None
     }
   }

--- a/films/src/test/resources/kill-your-darlings.json
+++ b/films/src/test/resources/kill-your-darlings.json
@@ -1,0 +1,22 @@
+{
+
+  "id": "film/2013/dec/05/kill-your-darlings-review",
+  "type": "article",
+  "sectionId": "film",
+  "sectionName": "Film",
+  "webPublicationDate": "2013-12-05T21:44:00Z",
+  "webTitle": "Kill Your Darlings – review | Peter Bradshaw",
+  "webUrl": "https://www.theguardian.com/film/2013/dec/05/kill-your-darlings-review",
+  "apiUrl": "https://content.guardianapis.com/film/2013/dec/05/kill-your-darlings-review",
+  "fields": {
+    "standfirst": "Daniel Radcliffe shines as Allen Ginsberg in a film that takes a deeper look at the birth of the beat generation",
+    "byline": "Peter Bradshaw",
+    "main": "",
+    "body": "<video data-media-id=\"gu-video-424126150\" class=\"gu-video\" controls=\"controls\" poster=\"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/12/4/1386166096782/Daniel-Radcliffe-and-Dane-025.jpg\"> <source src=\"http://cdn.theguardian.tv/mainwebsite/2013/12/04/131205KillYourDarlings2-16x9.mp4\"/><source src=\"http://cdn.theguardian.tv/3gp/small/2013/12/04/131205KillYourDarlings2_3gpSml16x9.3gp\"/><source src=\"http://cdn.theguardian.tv/webM/2013/12/04/131205KillYourDarlings2.webm\"/><source src=\"http://cdn.theguardian.tv/ad/2013/12/04/131205KillYourDarlings2/131205KillYourDarlings2.m3u8\"/><source src=\"http://cdn.theguardian.tv/3gp/large/2013/12/06/131205KillYourDarlings2_3gpLg16x9.3gp\"/> </video>   <p>Kill Your Darlings is the third film recently about the beat generation, after Rob Epstein and Jeffrey Friedman&apos;s Howl (2010) and Walter Salles&apos;s On the Road (2012). This movie by John Krokidas is superior to both, with Daniel Radcliffe giving an intelligent and considered performance as the young Allen Ginsberg.</p> <p>There is admittedly some of the same self-consciousness and 50s beat preciousness with polo-necked guys nodding life-affirmingly to live jazz. But it&apos;s also revealing about the role played by violence, shame and denial at the birth of beat and of Ginsberg&apos;s career. These ignited the poetry, and the film suggests that the poetic impulse is at least initially a flight impulse; an impulse away from a horrible real-world mess to a vantage point from where the mess can be artistically controlled, absorbed, acknowledged and accounted for. The story is about Ginsberg&apos;s relationship with Lucien Carr (Dane DeHaan) when they were students at Columbia: Carr was the troubled young aesthete to whom Ginsberg was to dedicate the first edition of Howl, and who was to be involved in a grisly act of violence. Radcliffe gives a forthright and candid performance as Ginsberg, very plausibly representing his idealism and sexual naivety. He is evolving into a formidable and potent screen presence.</p>",
+    "starRating": "3",
+    "creationDate": "2013-12-04T16:22:45Z",
+    "internalComposerCode": "56ad0c12e4b0af7546f71bf0"
+  },
+  "isHosted": false
+
+}

--- a/films/src/test/scala/com/gu/film_review_parser/FilmReviewParserSpec.scala
+++ b/films/src/test/scala/com/gu/film_review_parser/FilmReviewParserSpec.scala
@@ -31,4 +31,27 @@ class FilmReviewParserSpec extends FunSuite with Matchers {
 
     parsed should be(Some(expected))
   }
+
+  test("parse a 2013 review") {
+    val content = JsonHelpers.decodeFromFile[Content]("films/src/test/resources/kill-your-darlings.json")
+    val parsed = FilmReviewParser.parseContent(content)
+
+    val expected = ParsedFilmReview(
+      "film/2013/dec/05/kill-your-darlings-review",
+      "56ad0c12e4b0af7546f71bf0",
+      Some(OffsetDateTime.parse("2013-12-04T16:22:45Z")),
+      OffsetDateTime.parse("2013-12-05T21:44Z"),
+      "Peter Bradshaw",
+      3,
+      "Daniel Radcliffe shines as Allen Ginsberg in a film that takes a deeper look at the birth of the beat generation",
+      "Kill Your Darlings",
+      List("Biography", "Drama", "History"),
+      2013,
+      "tt1311071",
+      List("John Krokidas"),
+      List("Daniel Radcliffe", "Dane DeHaan", "Michael C. Hall", "Jack Huston")
+    )
+
+    parsed should be(Some(expected))
+  }
 }


### PR DESCRIPTION
In Feburary 2014 the webtitle format switched from:
`The Room - review`
To:
`The Room review - astonishing`