### PR TITLE
Ignore film reviews with certification in standfirst

### DIFF
--- a/films/src/main/scala/com/gu/film_review_parser/ParsedFilmReview.scala
+++ b/films/src/main/scala/com/gu/film_review_parser/ParsedFilmReview.scala
@@ -2,6 +2,7 @@ package com.gu.film_review_parser
 
 import java.time.OffsetDateTime
 
+import com.gu.contentapi.client.model.v1.Content
 import com.gu.contentatom.thrift.AtomData.Review
 import com.gu.contentatom.thrift.atom.review.{Rating, ReviewAtom, ReviewType}
 import com.gu.contentatom.thrift._
@@ -68,4 +69,27 @@ object ParsedFilmReview {
   }
 
   private def generateId(contentId: String): String = java.util.UUID.nameUUIDFromBytes(contentId.getBytes).toString
+
+  def reviewForTakedown(content: Content): Option[ParsedFilmReview] = {
+    for {
+      fields <- content.fields
+      internalComposerCode <- fields.internalComposerCode
+    } yield {
+      ParsedFilmReview(
+        contentId = content.id,
+        internalComposerCode = internalComposerCode,
+        creationDate = None,
+        publicationDate = OffsetDateTime.now,
+        reviewer = "",
+        rating = 0,
+        reviewSnippet = "",
+        title = "",
+        genre = Nil,
+        year = 0,
+        imdbId = "",
+        directors = Nil,
+        actors = Nil
+      )
+    }
+  }
 }

--- a/films/src/test/scala/com/gu/film_review_parser/PatternsSpec.scala
+++ b/films/src/test/scala/com/gu/film_review_parser/PatternsSpec.scala
@@ -1,0 +1,34 @@
+package com.gu.film_review_parser
+
+import com.gu.film_review_parser.parsers.FilmReviewParser
+import org.scalatest.{FunSuite, Matchers}
+
+class PatternsSpec extends FunSuite with Matchers {
+  test("match 'Titanic review - astonishing'") {
+    FilmReviewParser.getTitle("Titanic review - astonishing") should be(Some("Titanic"))
+  }
+
+  test("match 'Titanic - review'") {
+    FilmReviewParser.getTitle("Titanic - review") should be(Some("Titanic"))
+  }
+
+  test("match 'Film review: Titanic'") {
+    FilmReviewParser.getTitle("Film review: Titanic") should be(Some("Titanic"))
+  }
+
+  test("not match 'This is not a proper film review'") {
+    FilmReviewParser.getTitle("This is not a proper film review") should be(None)
+  }
+
+  test("not match 'This is not: a proper film review'") {
+    FilmReviewParser.getTitle("This is not: a proper film review") should be(None)
+  }
+
+  test("not match standfirst of '(Cert 15)'") {
+    FilmReviewParser.getReviewSnippet("(Cert 15)") should be(None)
+  }
+
+  test("match standfirst of 'This is a good reviewSnippet'") {
+    FilmReviewParser.getReviewSnippet("This is a good reviewSnippet") should be(Some("This is a good reviewSnippet"))
+  }
+}


### PR DESCRIPTION
While parsing film reviews, the software started sending in some bad results when it got to 2008 articles. See `PatternsSpec.scala ` for examples of the things we allow and exclude.

With this change, it will clean up by sending takedowns for any articles which cannot be parsed (this logic can be removed later).