### PR TITLE
Review Parser - Remove phone number from formatted address field

### DIFF
--- a/common/src/main/scala/utils/PhoneNumberRegexes.scala
+++ b/common/src/main/scala/utils/PhoneNumberRegexes.scala
@@ -1,0 +1,16 @@
+package utils
+
+object PhoneNumberRegexes {
+
+  val regexes = Seq(
+    """.*(\d{3}-\d{4}\s\d{4})""".r,        // matches 020-7437 5708
+    """.*(d{3}-\d{3}\s\d{4})""".r,         // matches 020-734 7737
+    """.*(\d{5}\s\d{6})""".r,              // matches 01227 276856
+    """.*(\d{5}\s\d{3}\s\d{3})""".r,       // matches 01179 028 326
+    """.*(\d{4}\s\d{3}\s\d{4})""".r,       // matches 0203 745 7227
+    """.*(\d{4}-\d{7})""".r,               // matches 0141-2042081
+    """.*(\d{6}\s\d{5})""".r,              // matches 015394 22012
+    """.*(\d{3}\s\d{3}\s\d{3}\s\d{4})""".r // matches 001 646 703 2715
+  )
+
+}

--- a/restaurants/src/test/scala/com/gu/restaurant_review_parser/parsers/RestaurantReviewProcessorSpec.scala
+++ b/restaurants/src/test/scala/com/gu/restaurant_review_parser/parsers/RestaurantReviewProcessorSpec.scala
@@ -53,11 +53,10 @@ class RestaurantReviewProcessorSpec extends FunSuite with Matchers {
 
       review.restaurantName.get shouldBe RestaurantName("John Salt")
       review.webAddress shouldBe Some(WebAddress("http://john-salt.com/"))
-      println("BREAKDOWN: " + review.ratingBreakdown)
       review.ratingBreakdown shouldBe Some(OverallRating(0, 4, 5))
       review.publicationDate shouldBe OffsetDateTime.parse(webPublicatioDate)
       review.creationDate shouldBe Some(OffsetDateTime.parse(creationDate))
-      review.address shouldBe Some(FormattedAddress("131 Upper Street, London N1, 020-7704 8955"))
+      review.address shouldBe Some(FormattedAddress("131 Upper Street, London N1"))
       review.addressInformation shouldBe Some(AddressInformation(AddressParts(Some(StreetNumber("131")),Some(Route("Upper Street")),Some(Neighborhood("Islington")),Some(Locality("London")),Some(PostalCode("N1")),Some(PostalTown("London")),Some(Country("United Kingdom")),Some(AdministrativeAreaLevelOne("England")),Some(AdministrativeAreaLevelTwo("Greater London"))),Location(51.5390429,-0.1026274)))
       review.restaurantInformation shouldBe Some(RestaurantInformation("Open dinner, Tue-Sat, 6-10pm; Sat brunch, 10am-3pm; Sun lunch noon-4pm. Set menus: four-course, £28, eight £56, 12 £85, plus drinks and service."))
       review.approximateLocation.get shouldBe ApproximateLocation("London N1")

--- a/restaurants/src/test/scala/com/gu/restaurant_review_parser/parsers/marinaOLoughlin/MarinaOLoughlinParseAddressSpec.scala
+++ b/restaurants/src/test/scala/com/gu/restaurant_review_parser/parsers/marinaOLoughlin/MarinaOLoughlinParseAddressSpec.scala
@@ -12,7 +12,7 @@ class MarinaOLoughlinParseAddressSpec extends FlatSpec with Matchers {
     val articleBody = ArticleBody(TestUtils.resourceToString("articles/marinaOLoughlin/lifeandstyle-2012-dec-07-john-salt-london-restaurant-review.txt"))
     val restaurantName = RestaurantName("John Salt")
     val address = MarinaOLoughlinReviewParser.guessFormattedAddress(articleBody, restaurantName)
-    address shouldBe Some(FormattedAddress("131 Upper Street, London N1, 020-7704 8955"))
+    address shouldBe Some(FormattedAddress("131 Upper Street, London N1"))
   }
 
   it should "extract the restaurant information" in {
@@ -26,7 +26,7 @@ class MarinaOLoughlinParseAddressSpec extends FlatSpec with Matchers {
     val articleBody = ArticleBody(TestUtils.resourceToString("articles/marinaOLoughlin/lifeandstyle-2012-nov-02-the-table-cafe-london-review.txt"))
     val restaurantName = RestaurantName("The Table Cafe")
     val address = MarinaOLoughlinReviewParser.guessFormattedAddress(articleBody, restaurantName)
-    address shouldBe Some(FormattedAddress("83 Southwark Street, London SE1, 020-7401 2760"))
+    address shouldBe Some(FormattedAddress("83 Southwark Street, London SE1"))
   }
 
   it should "extract the restaurant information (2)" in {


### PR DESCRIPTION
By removing the phone number from the formatted address field we can drastically increase our chances of success when querying Google for location based information. This also has the added benefit of providing us with the ability to extract the phone number for a restaurant and adding it to our model if we so wish.